### PR TITLE
Implements user configurable test-mode (`adam test`)

### DIFF
--- a/docs/CONFIG_FILE_GUIDE.md
+++ b/docs/CONFIG_FILE_GUIDE.md
@@ -148,6 +148,26 @@ gms2_install_location = "C:/Program Files/Steam/common/GameMaker Studio 2/GameMa
 }
 ```
 
+### test_env_variables
+
+> Type: Vec<String>
+>
+> Default Windows: []
+> Default Mac: []
+
+Sets environment variables when running `adam test`. `adam test` is the same as `adam run`, but with
+these environment variables set.
+
+```toml
+test_env_variables = ["TEST_ENV_VARIABLE"]
+```
+
+```json
+{
+    "test_env_variables": ["TEST_ENV_VARIABLE"]
+}
+```
+
 ## How the CLI and Config Files Interact
 
 Options passed into the CLI and the Config Files are **additive**, but in the case of conflicts, the CLI wins. This will allow users, for example, to set their default configuration as `"Debug"`, but pass in `-c "Release"` during times when they would like to change their configuration temporarily.

--- a/src/input/cli.rs
+++ b/src/input/cli.rs
@@ -29,6 +29,9 @@ pub enum ClapOperation {
 
     /// Creates a release executable, running `clean` first.
     Release(CliOptions),
+ 
+    /// Runs the project, enabling any `test_env_variables` set in the config.
+    Test(CliOptions),
 
     /// Cleans a project target directory.
     Clean(CleanOptions),

--- a/src/input/config_file.rs
+++ b/src/input/config_file.rs
@@ -82,7 +82,7 @@ pub struct ConfigFile {
 
     /// A list of environment variable names that will be set to "1" if running `adam test`.
     #[serde(default)]
-    pub test_env_variables: Option<Vec<String>>,
+    pub test_env_variables: Vec<String>,
 }
 
 impl ConfigFile {
@@ -141,36 +141,9 @@ impl ConfigFile {
             run_options.platform.user_license_folder = o;
         }
         run_options.task.no_user_folder = self.no_user_folder;
-
-        if let Some(test_env_variables) = self.test_env_variables {
-            run_options.task.test_env_variables = test_env_variables;
-        }
+        run_options.task.test_env_variables = self.test_env_variables;
     }
 }
-
-// impl From<ConfigFile> for crate::RunOptions {
-//     fn from(o: ConfigFile) -> Self {
-//         Self {
-//             yyc: false,
-//             config: o.configuration.unwrap_or_else(|| "Default".to_string()),
-//             verbosity: o.verbosity.unwrap_or_default(),
-//             output_folder: o
-//                 .output_folder
-//                 .unwrap_or_else(|| camino::Utf8Path::new("target").to_owned()),
-//             gms2_install_location: o
-//                 .gms2_install_location
-//                 .unwrap_or_else(|| crate::PlatformBuilder::generate()),
-//             ignore_cache: o.ignore_cache.unwrap_or_default(),
-//             beta: o.beta,
-//             runtime: o.runtime,
-//             x64_windows: o.x64_windows,
-//             runtime_location_override: o.runtime_location_override,
-//             visual_studio_path: o.visual_studio_path,
-//             user_license_folder: o.user_license_folder,
-//             no_user_folder: o.no_user_folder,
-//         }
-//     }
-// }
 
 impl ConfigFile {
     pub fn find_config() -> Option<ConfigFile> {

--- a/src/input/config_file.rs
+++ b/src/input/config_file.rs
@@ -79,6 +79,10 @@ pub struct ConfigFile {
     /// `user_folder` at all.
     #[serde(default)]
     pub user_license_folder: Option<Utf8PathBuf>,
+
+    /// A list of environment variable names that will be set to "1" if running `adam test`.
+    #[serde(default)]
+    pub test_env_variables: Option<Vec<String>>,
 }
 
 impl ConfigFile {
@@ -137,6 +141,10 @@ impl ConfigFile {
             run_options.platform.user_license_folder = o;
         }
         run_options.task.no_user_folder = self.no_user_folder;
+
+        if let Some(test_env_variables) = self.test_env_variables {
+            run_options.task.test_env_variables = test_env_variables;
+        }
     }
 }
 

--- a/src/input/get_input.rs
+++ b/src/input/get_input.rs
@@ -20,6 +20,7 @@ pub enum RunKind {
     Run,
     Build,
     Release,
+    Test,
 }
 
 pub fn parse_inputs() -> AnyResult<(RunOptions, Operation)> {
@@ -45,6 +46,7 @@ pub fn parse_inputs() -> AnyResult<(RunOptions, Operation)> {
         ClapOperation::Run(b) => (b, Operation::Run(RunKind::Run)),
         ClapOperation::Build(b) => (b, Operation::Run(RunKind::Build)),
         ClapOperation::Release(b) => (b, Operation::Run(RunKind::Release)),
+        ClapOperation::Test(b) => (b, Operation::Run(RunKind::Test)),
         ClapOperation::Clean(co) => (
             cli::CliOptions {
                 output_folder: co.output_folder,

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,13 @@ fn main() -> AnyResult {
         }
     };
 
+    // fire any specific behavior to this run kind
+    if run_kind == input::RunKind::Test {
+        for var in options.task.test_env_variables.iter() {
+            std::env::set_var(var, "1");
+        }
+    }
+
     // check if we have a valid yyc bat
     if options.task.yyc {
         if cfg!(not(target_os = "windows")) {

--- a/src/runner/compiler_handler.rs
+++ b/src/runner/compiler_handler.rs
@@ -27,6 +27,10 @@ impl CompilerHandler {
         Self(CompilerState::Initialize, false)
     }
 
+    pub fn new_test() -> Self {
+        Self(CompilerState::Initialize, false)
+    }
+
     #[cfg(target_os = "windows")]
     pub fn new_rerun() -> Self {
         Self(CompilerState::PreRunToMainLoop(vec![]), false)

--- a/src/runner/run.rs
+++ b/src/runner/run.rs
@@ -16,6 +16,7 @@ impl std::fmt::Display for RunCommand {
         let word = match self.0 {
             RunKind::Run | RunKind::Build => "compile",
             RunKind::Release => "release",
+            RunKind::Test => "test",
         };
 
         write!(f, "{} {}", if self.1.task.yyc { "yyc" } else { "vm" }, word)
@@ -30,7 +31,9 @@ pub fn run_command(
 ) {
     let sub_command = RunCommand(run_kind, run_options);
     let mut child = match sub_command.0 {
-        RunKind::Run | RunKind::Build => invoke_run(&macros, build_bff, &sub_command),
+        RunKind::Run | RunKind::Build | RunKind::Test => {
+            invoke_run(&macros, build_bff, &sub_command)
+        }
         RunKind::Release => invoke_release(&macros, build_bff, &sub_command),
     };
 
@@ -44,6 +47,7 @@ pub fn run_command(
             RunKind::Run => CompilerHandler::new_run(),
             RunKind::Build => CompilerHandler::new_build(),
             RunKind::Release => CompilerHandler::new_release(),
+            RunKind::Test => CompilerHandler::new_test(),
         };
         // startup the printer in a separate thread...
         let project_dir = macros.project_dir.clone();

--- a/src/runner/run_options.rs
+++ b/src/runner/run_options.rs
@@ -39,6 +39,9 @@ pub struct TaskOptions {
 
     /// Ignore cache. Can use multiples times, like `-ii`. >0 disables quick recompiles, >1 disables all caching.
     pub ignore_cache: usize,
+
+    /// A list of environment variable names that will be set to "1" if running `adam test`.
+    pub test_env_variables: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -113,6 +116,7 @@ impl Default for TaskOptions {
             verbosity: 0,
             output_folder: "target".into(),
             ignore_cache: 0,
+            test_env_variables: vec![],
         }
     }
 }


### PR DESCRIPTION
Adds `adam test`, which pulls in the optional value `test_env_variables` from the user's config and sets any names that appear to `"1"` in the running environment. After that, it proceeds like a normal `adam run`.

This will allow users to easily run any testing frameworks (or whatever they please) by giving a means to communicate with the GM Runner through adam.

...ignore my commit name, I have absolutely no idea how that happened?