### PR TITLE
implements user configurable check command (`adam check`)

### DIFF
--- a/src/input/cli.rs
+++ b/src/input/cli.rs
@@ -21,6 +21,10 @@ pub struct InputOpts {
 
 #[derive(Parser, Debug)]
 pub enum ClapOperation {
+    /// Runs the user specified check command. Takes the command name
+    /// as well as a list of args to pass in.
+    Check,
+
     /// Builds a project *without* running it.
     Build(CliOptions),
 

--- a/src/input/config_file.rs
+++ b/src/input/config_file.rs
@@ -79,6 +79,19 @@ pub struct ConfigFile {
     /// `user_folder` at all.
     #[serde(default)]
     pub user_license_folder: Option<Utf8PathBuf>,
+
+    /// The command to run when executing a check.
+    #[serde(default)]
+    pub check_command: Option<String>,
+
+    /// The arguments to pass the check command when executing a check.
+    #[serde(default)]
+    pub check_args: Option<Vec<String>>,
+
+    /// If true, will always run the check command prior to executing a build, run, or release.
+    /// If the command returns a non-zero status, adam will not continue its operation.
+    #[serde(default)]
+    pub always_check: bool,
 }
 
 impl ConfigFile {
@@ -137,6 +150,16 @@ impl ConfigFile {
             run_options.platform.user_license_folder = o;
         }
         run_options.task.no_user_folder = self.no_user_folder;
+
+        if let Some(check_command) = self.check_command {
+            run_options.task.check_command = Some(check_command);
+            if let Some(check_args) = self.check_args {
+                run_options.task.check_args = Some(check_args);
+            }
+            if self.always_check {
+                run_options.task.always_check = true;
+            }
+        }
     }
 }
 

--- a/src/input/get_input.rs
+++ b/src/input/get_input.rs
@@ -13,6 +13,7 @@ use super::{
 pub enum Operation {
     Run(RunKind),
     Clean,
+    Check,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Ord, PartialOrd)]
@@ -42,6 +43,7 @@ pub fn parse_inputs() -> AnyResult<(RunOptions, Operation)> {
 
     let value: cli::InputOpts = cli::InputOpts::parse();
     let (cli_options, operation) = match value.subcmd {
+        ClapOperation::Check => (cli::CliOptions::default(), Operation::Check),
         ClapOperation::Run(b) => (b, Operation::Run(RunKind::Run)),
         ClapOperation::Build(b) => (b, Operation::Run(RunKind::Build)),
         ClapOperation::Release(b) => (b, Operation::Run(RunKind::Release)),

--- a/src/runner/run_options.rs
+++ b/src/runner/run_options.rs
@@ -39,6 +39,16 @@ pub struct TaskOptions {
 
     /// Ignore cache. Can use multiples times, like `-ii`. >0 disables quick recompiles, >1 disables all caching.
     pub ignore_cache: usize,
+
+    /// The name of the check command to run, if any
+    pub check_command: Option<String>,
+
+    /// The arguments to pass to the check command, if any
+    pub check_args: Option<Vec<String>>,
+
+    /// If true, will always run the check command prior to executing a build, run, or release.
+    /// If the command returns a non-zero status, adam will not continue its operation.
+    pub always_check: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -113,6 +123,9 @@ impl Default for TaskOptions {
             verbosity: 0,
             output_folder: "target".into(),
             ignore_cache: 0,
+            check_command: None,
+            check_args: None,
+            always_check: false,
         }
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 cargo build;
-cd ../../Gms2/SwordAndField;
-./../../Rust/adam/target/debug/adam build;
-cd ../../Rust/adam;
+cd ../SwordAndField;
+../adam/target/debug/adam run;
+cd ../adam;

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 cargo build;
-cd ../SwordAndField;
-../adam/target/debug/adam run;
-cd ../adam;
+cd ../../Gms2/SwordAndField;
+./../../Rust/adam/target/debug/adam build;
+cd ../../Rust/adam;


### PR DESCRIPTION
This is a proposal for (and working implementation of) `adam check`, which pulls in the optional values `check_command` and `check_args` from the users config. Executes them as a command, printing the results into the output.

Additionally adds `always_check` to the config, which instructs adam to always execute a check prior to performing a run, build, or release. If the command returns a non-zero status, the build will be canceled.

This allows users to insert any sort of behavior they'd like to run prior to building their game, like, for example, if a new GML linter were to suddenly become available (though, jokes aside, this could in theory run Feather and enforce that it passes too).

Since there are two spots that checks can be run, I placed the logic in a free-floating function in `main.rs`, which may not be optimal -- please let me know if you want me to make any adjustments!

I once again have no idea what happened to my commit name. Moral of the story: don't include backticks in commit messages!