### PR TITLE
Fixes `--config` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,16 +117,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.5"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f34b09b9ee8c7c7b400fe2f8df39cafc9538b03d6ba7f4ae13e4cb90bfbb7d"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -134,15 +134,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.5"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a0645a430ec9136d2d701e54a95d557de12649a9dd7109ced3187e648ac824"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -387,9 +396,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "owo-colors"
@@ -592,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"

--- a/src/input/cli.rs
+++ b/src/input/cli.rs
@@ -5,14 +5,14 @@ use crate::{RunOptions, DEFAULT_PLATFORM_DATA};
 
 /// A CLI intended for use by humans and machines to build GameMakerStudio 2 projects.
 #[derive(Parser, Debug)]
-#[clap(version = clap::crate_version!(), author = clap::crate_authors!())]
+#[clap(version, author)]
 pub struct InputOpts {
     #[clap(subcommand)]
     pub subcmd: ClapOperation,
 
     /// The path to a non-standard named configuration file. Possible names are .adam, .adam.json, and adam.toml
-    #[clap(short, long)]
-    pub config: Option<String>,
+    #[clap(short, long, parse(from_os_str))]
+    pub config: Option<std::path::PathBuf>,
 
     /// Prints version information
     #[clap(short, long)]

--- a/src/input/get_input.rs
+++ b/src/input/get_input.rs
@@ -60,11 +60,11 @@ pub fn parse_inputs() -> AnyResult<(RunOptions, Operation)> {
 
         RunOptions { task, platform }
     };
-    config_file::ConfigFile::find_config()
+    let value: cli::InputOpts = cli::InputOpts::parse();
+    config_file::ConfigFile::find_config(value.config.as_ref())
         .unwrap_or_default()
         .write_to_options(&mut runtime_options);
 
-    let value: cli::InputOpts = cli::InputOpts::parse();
     let (cli_options, operation) = match value.subcmd {
         ClapOperation::Run(b) => (b, Operation::Run(RunKind::Run)),
         ClapOperation::Build(b) => (b, Operation::Run(RunKind::Build)),


### PR DESCRIPTION
The config option (`adam -c ./path`) is currently valid to pass but does not do anything. I refactored `find_config` to re-enable this feature as well as simplify the search process a bit in the event that the user does not pass anything.