### PR TITLE
Implement `--runtime` to print current runtime information

### DIFF
--- a/src/input/cli.rs
+++ b/src/input/cli.rs
@@ -8,7 +8,7 @@ use crate::{RunOptions, DEFAULT_PLATFORM_DATA};
 #[clap(version, author)]
 pub struct InputOpts {
     #[clap(subcommand)]
-    pub subcmd: ClapOperation,
+    pub subcmd: Option<ClapOperation>,
 
     /// The path to a non-standard named configuration file. Possible names are .adam, .adam.json, and adam.toml
     #[clap(short, long, parse(from_os_str))]
@@ -17,6 +17,10 @@ pub struct InputOpts {
     /// Prints version information
     #[clap(short, long)]
     pub version: bool,
+
+    /// Prints the GM runtime this directory is set up to use.
+    #[clap(short, long)]
+    pub runtime: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/input/get_input.rs
+++ b/src/input/get_input.rs
@@ -1,15 +1,11 @@
 use std::fmt;
 
 use camino::Utf8Path;
-use clap::Parser;
 use color_eyre::Help;
 
-use crate::{AnyResult, PlatformOptions, RunOptions, TaskOptions, DEFAULT_PLATFORM_DATA};
+use crate::{AnyResult, RunOptions};
 
-use super::{
-    cli::{self, ClapOperation},
-    config_file,
-};
+use super::cli::{self, ClapOperation};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Ord, PartialOrd)]
 pub enum Operation {
@@ -46,26 +42,11 @@ impl fmt::Display for RunKind {
     }
 }
 
-pub fn parse_inputs() -> AnyResult<(RunOptions, Operation)> {
-    let mut runtime_options = {
-        let platform: PlatformOptions = PlatformOptions {
-            gms2_application_location: DEFAULT_PLATFORM_DATA.stable_application_path.into(),
-            runtime_location: DEFAULT_PLATFORM_DATA.stable_runtime_location.into(),
-            visual_studio_path: Default::default(),
-            user_license_folder: Default::default(),
-            home_dir: DEFAULT_PLATFORM_DATA.home_dir.clone(),
-            compiler_cache: DEFAULT_PLATFORM_DATA.stable_cached_data.clone(),
-        };
-        let task = TaskOptions::default();
-
-        RunOptions { task, platform }
-    };
-    let value: cli::InputOpts = cli::InputOpts::parse();
-    config_file::ConfigFile::find_config(value.config.as_ref())
-        .unwrap_or_default()
-        .write_to_options(&mut runtime_options);
-
-    let (cli_options, operation) = match value.subcmd {
+pub fn parse_inputs(
+    operation: ClapOperation,
+    mut runtime_options: RunOptions,
+) -> AnyResult<(RunOptions, Operation)> {
+    let (cli_options, operation) = match operation {
         ClapOperation::Run(b) => (b, Operation::Run(RunKind::Run)),
         ClapOperation::Build(b) => (b, Operation::Run(RunKind::Build)),
         ClapOperation::Release(b) => (b, Operation::Run(RunKind::Release)),


### PR DESCRIPTION
This has two main parts:

1. Implements `--runtime` to print the GM runtime version adam is set up to use in the current directory
2. Reorganizes the startup process a bit to separate the loading of the config / parsing of the clap values from the execution of subcommands to make the above possible

My use case is for [starship](https://starship.rs) -- I have a fork with support for adam working (see below!). By letting `adam` itself tell me what runtime the user is using, I can make starship work for users who aren't using a config file for adam.

![image](https://user-images.githubusercontent.com/39664206/168487008-9f8aff62-0482-41de-90be-b6c733c2bb03.png)
