### PR TITLE
Updates README/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,29 @@
 > I am thy creature: I ought to be thy Adam, but I am rather the fallen angel, whom thou drivest from joy for no misdeed.
 > -- Frankenstein's Monster in *Frankenstein* by Mary Shelly
 
-adam is a command-line utility for compiling Gms2 projects on Windows 10 and Mac OS Catalina. Invoking adam is trivial:
+adam is a command-line utility for compiling GameMaker projects on Windows and macOS. Invoking adam is trivial:
 
 ```sh
 adam run
 ```
 
-This will compile your project, run it, and give you stdout (`"show_debug_message"`) with colorization and links. `adam` supports compiling with the VM (default) and the YYC (by passing in `--yyc`). `adam` also supports faster recompilation than Gms2 does, so if users recompile a game without making changes, their game will instantly load, without invoking the compiler at all. This is especially useful, since `adam` easily allows you to run multiple instances of your game at the same time on your machine.
+This will compile your project, run it, and give you stdout (`"show_debug_message"`) with colorization and links. `adam` supports compiling with the VM (default) and the YYC (by passing in `--yyc`). `adam` also supports faster recompilation than GameMaker does, so if users recompile a game without making changes, their game will instantly load, without invoking the compiler at all. This is especially useful, since `adam` easily allows you to run multiple instances of your game at the same time on your machine.
 
 `adam` will place all its generated artifacts within a folder relative to the working directory -- by default, it will use `"target"` as its output output. **It is highly advised that you add your output directory to your .gitignore.**
 
-Additionally, `adam` has the commands `build`, which builds a project without running it (but will report compile errors), `release`, which releases a Zip of the project (but only if you have an Enterprise license), and `clean`, which cleans the output directory.
+## COMMANDS
+
+`run`: Builds and runs the project.
+
+`build`: Builds a project without running it (but will report compile errors)
+
+`release`: Builds a zip of the project (only available for users with an Enterprise license)
+
+`clean`: Cleans the output directory
+
+`test`: Runs the game after setting user-defined environment variables. See the [config file guide](docs/CONFIG_FILE_GUIDE.md) for more information.
+
+You can also run `adam help` to see a more detailed version of the above.
 
 ## INSTALLATION
 
@@ -49,7 +61,7 @@ Please see the [CHANGELOG](CHANGELOG.md) for release history, and the [ROADMAP](
 
 You will likely need to customize an `adam` command for most usages. To see CLI options, simply run `adam run --help`:
 
-Of special note, please see `--yyc`, which will allow users to compile using the Yyc, and `-c`, which allows users to pass in a configuration.
+Of special note, please see `--yyc`, which will allow users to compile using the YYC, and `-c`, which allows users to pass in a configuration.
 
 However, passing in numerous values every compile can become tiresome. To support this, users can create a config file in either `JSON` or `TOML`, where these options can be specified. To create an adam configuration file, please follow [this guide](docs/CONFIG_FILE_GUIDE.md).
 

--- a/docs/CONFIG_FILE_GUIDE.md
+++ b/docs/CONFIG_FILE_GUIDE.md
@@ -130,8 +130,8 @@ ignore_cache = 1
 
 > Type: String
 >
-> Default Windows: C:/Program Files/GameMaker Studio 2/GameMakerStudio.exe
-> Default Mac: /Applications/GameMaker Studio 2.app
+> Default Windows: C:/Program Files/GameMaker Studio 2/GameMaker.exe
+> Default Mac: /Applications/GameMaker.app
 
 Uses a non-standard Gms2 install location. If you have installed Gms2 with Steam, this is required.
 
@@ -139,12 +139,12 @@ Uses a non-standard Gms2 install location. If you have installed Gms2 with Steam
 **Mac**: please provide a path just to the `.app` file. Do not index within the `.app` file -- adam will handle that.
 
 ```toml
-gms2_install_location = "C:/Program Files/Steam/common/GameMaker Studio 2/GameMakerStudio.exe"
+gms2_install_location = "C:/Program Files/Steam/common/GameMaker Studio 2/GameMaker.exe"
 ```
 
 ```json
 {
-    "gms2_install_location": "C:/Program Files/Steam/common/GameMaker Studio 2/GameMakerStudio.exe"
+    "gms2_install_location": "C:/Program Files/Steam/common/GameMaker Studio 2/GameMaker.exe"
 }
 ```
 

--- a/src/input/config_file.rs
+++ b/src/input/config_file.rs
@@ -26,8 +26,8 @@ pub struct ConfigFile {
 
     /// An absolute path to the Gms2 install location on the system.
     ///
-    /// On Windows, this defaults to `C:\Program Files\GameMaker Studio 2\GameMakerStudio.exe`.
-    /// On macOS, this default to `/Applications/GameMaker Studio 2.app`. (For macOS, you can point to just
+    /// On Windows, this defaults to `C:\Program Files\GameMaker Studio 2\GameMaker.exe`.
+    /// On macOS, this default to `/Applications/GameMaker.app`. (For macOS, you can point to just
     /// the .app -- internally, we will search inside the app bundle for the executable)
     pub gms2_install_location: Option<Utf8PathBuf>,
 


### PR DESCRIPTION
Updates various elements of the markdown files that were out of date / adds some badges to the top of the readme.

Two things I noticed but didn't address though:

First: We have this line in the readme: > `adam` also supports faster recompilation than GameMaker does, so if users recompile a game without making changes, their game will instantly load, without invoking the compiler at all.

I don't think this is true on either platform right now -- I think it worked a long time ago but hasn't for a while. I'm not sure if it's something we can fix or if we should just remove that from the readme.

Second: The roadmap is pretty out of date -- same thing where I dunno if it'd be better to update it or just yoink it out, since there aren't any large feature additions to adam that I'm aware of.