### PR TITLE
Adjust `check`'s output behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,48 +153,18 @@ fn main() -> ExitCode {
     let run_kind = match operation {
         input::Operation::Run(inner) => {
             if let Some(check_options) = check_options {
-                if let Err(output) = runner::run_check(check_options) {
-                    println!(
-                        "{}: check FAILED with {}",
-                        console::style("adam error").bright().red(),
-                        output.status
-                    );
-                    if let Ok(value) = String::from_utf8(output.stdout) {
-                        println!("---stdout of check command---");
-                        println!("{}", value);
-                    }
-                    if let Ok(value) = String::from_utf8(output.stderr) {
-                        println!("---stderr of check command---");
-                        println!("{}", value);
-                    }
-
+                if runner::run_check(check_options).is_err() {
                     return ExitCode::FAILURE;
                 }
             }
-
             inner
         }
         input::Operation::Check => {
             let check_options = check_options.unwrap();
-            // run the check!
-            if let Err(output) = runner::run_check(check_options) {
-                println!(
-                    "{}: check FAILED with {}",
-                    console::style("adam error").bright().red(),
-                    output.status
-                );
-                if let Ok(value) = String::from_utf8(output.stdout) {
-                    println!("---stdout of check command---");
-                    println!("{}", value);
-                }
-                if let Ok(value) = String::from_utf8(output.stderr) {
-                    println!("---stderr of check command---");
-                    println!("{}", value);
-                }
-
-                return ExitCode::FAILURE;
-            } else {
+            if runner::run_check(check_options).is_ok() {
                 return ExitCode::SUCCESS;
+            } else {
+                return ExitCode::FAILURE;
             }
         }
         input::Operation::Clean => {

--- a/src/runner/check_options.rs
+++ b/src/runner/check_options.rs
@@ -47,11 +47,13 @@ pub fn run_check(check_options: CheckOptions) -> Result<(), ()> {
 
     if let Ok(value) = String::from_utf8(output.stderr) {
         if !value.is_empty() {
-            println!("{value}");
+            print!("{value}");
         }
     }
     if let Ok(value) = String::from_utf8(output.stdout) {
-        print!("{value}");
+        if !value.is_empty() {
+            print!("{value}");
+        }
     }
 
     if output.status.success() {

--- a/src/runner/check_options.rs
+++ b/src/runner/check_options.rs
@@ -46,10 +46,12 @@ pub fn run_check(check_options: CheckOptions) -> Result<(), ()> {
     let output = cmd.output().expect("Failed to execute command");
 
     if let Ok(value) = String::from_utf8(output.stderr) {
-        println!("{value}");
+        if !value.is_empty() {
+            println!("{value}");
+        }
     }
     if let Ok(value) = String::from_utf8(output.stdout) {
-        println!("{value}");
+        print!("{value}");
     }
 
     if output.status.success() {

--- a/src/runner/check_options.rs
+++ b/src/runner/check_options.rs
@@ -12,14 +12,14 @@ pub struct CheckOptions {
 fn harness_check(check_options: CheckOptions) -> Command {
     let current_dir = Utf8PathBuf::from_path_buf(std::env::current_dir().unwrap()).unwrap();
 
-    let cmd = Command::new("powershell");
+    let mut cmd = Command::new("powershell");
     cmd.arg("-ExecutionPolicy")
         .arg("RemoteSigned")
         .arg("-File")
         .arg(current_dir.join(&check_options.path_to_run));
 
     if let Some(d2u) = check_options.directory_to_use {
-        let dir_to_use = current_dir.join(&d2u);
+        let dir_to_use = current_dir.join(d2u);
         cmd.current_dir(dir_to_use);
     }
 
@@ -30,10 +30,10 @@ fn harness_check(check_options: CheckOptions) -> Command {
 fn harness_check(check_options: CheckOptions) -> Command {
     let current_dir = std::env::current_dir().unwrap();
     let path = current_dir.join(&check_options.path_to_run);
-    let mut cmd = Command::new(&path);
+    let mut cmd = Command::new(path);
 
     if let Some(d2u) = check_options.directory_to_use {
-        let dir_to_use = current_dir.join(&d2u);
+        let dir_to_use = current_dir.join(d2u);
         cmd.current_dir(dir_to_use);
     }
 
@@ -51,6 +51,7 @@ pub fn run_check(check_options: CheckOptions) -> Result<(), ()> {
     if let Ok(value) = String::from_utf8(output.stdout) {
         println!("{value}");
     }
+
     if output.status.success() {
         Ok(())
     } else {
@@ -59,6 +60,7 @@ pub fn run_check(check_options: CheckOptions) -> Result<(), ()> {
             console::style("adam error").bright().red(),
             output.status
         );
+
         Err(())
     }
 }


### PR DESCRIPTION
Adjust's adam check to print the output of its `check` command even if it passes. I had to restructure things a little bit to prevent me from duplicating a lot of code in two places